### PR TITLE
Add "confidence_pct" parameter to sendAppriseNotifications call

### DIFF
--- a/BirdNET-Pi/server.py
+++ b/BirdNET-Pi/server.py
@@ -292,6 +292,7 @@ def handle_client(conn, addr):
                                     settings_dict = config_to_settings(userDir + '/BirdNET-Pi/scripts/thisrun.txt')
                                     sendAppriseNotifications(species2,
                                                              str(score),
+                                                             str(round(score * 100)),
                                                              File_Name,
                                                              Date,
                                                              Time,


### PR DESCRIPTION
At some point sendAppriseNotifications() in BirdNET-Pi seems to have grown another parameter..